### PR TITLE
Update Dogecoin price to use Poloniex BTC_DOGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.0.7 - 2017-11-09
+* Use Poloniex API for polling BTC:DOGE rate
+
 ## v0.0.6 - 2014-05-28
 
 * Add pollers for doge to btc and btc to usd rates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name":         "hubot-dogecoin",
-  "version":      "0.0.6",
+  "version":      "0.0.7",
   "description":  "Hubot script for tipping with Dogecoin.",
   "author":       "Jico Baligod <jico@baligod.com>",
   "licenses": [

--- a/scripts/dogebot.coffee
+++ b/scripts/dogebot.coffee
@@ -14,7 +14,7 @@ class Dogebot
   constructor: (@robot) ->
     @slug = @robot.name.replace(/[^a-zA-Z0-9 -]/g, '').replace(/\W+/g, '-')
 
-    _dogeBtcApiUrl = "https://data.bter.com/api/1/ticker/doge_btc"
+    _dogeBtcApiUrl = "https://poloniex.com/public?command=returnTicker"
     _btcUsdAPIUrl  = "https://www.bitstamp.net/api/ticker/"
     @doge_btc = 0
     @btc_usd  = 0
@@ -31,7 +31,7 @@ class Dogebot
             # TODO: Handle parse error here
            return
 
-          @doge_btc = parseFloat(data.last)
+          @doge_btc = parseFloat(data.BTC_DOGE.last)
 
       # Poll for btc to usd
       @robot.http(_btcUsdAPIUrl)

--- a/test/dogebot.coffee
+++ b/test/dogebot.coffee
@@ -28,17 +28,18 @@ describe 'Dogebot', ->
       expect(dogebot.slug).to.be('Doge-bot')
 
     it 'polls exchanges for doge/btc/usd exchange rates', ->
-      dogeBtcUrl = "https://data.bter.com/api/1/ticker/doge_btc"
+      dogeBtcUrl = "https://poloniex.com/public?command=returnTicker"
       btcUsdUrl  = "https://www.bitstamp.net/api/ticker/"
 
       dogeBtcResp =
         statusCode: 200
         body:
-          result: "true"
-          last:   "0.00000069"
-          high:   "0.00000073"
-          low:    "0.00000065"
-          avg:    "0.00000070"
+          BTC_DOGE:
+            result: "true"
+            last:   "0.00000069"
+            high:   "0.00000073"
+            low:    "0.00000065"
+            avg:    "0.00000070"
 
       btcUsdResp =
         statusCode: 200
@@ -65,7 +66,7 @@ describe 'Dogebot', ->
       @robot.http = httpStub
 
       dogebot = new Dogebot(@robot)
-      expect(dogebot.doge_btc).to.eql(parseFloat(dogeBtcResp.body.last))
+      expect(dogebot.doge_btc).to.eql(parseFloat(dogeBtcResp.body.BTC_DOGE.last))
       expect(dogebot.btc_usd).to.eql(parseFloat(btcUsdResp.body.last))
 
     it.skip 'updates doge/btc/usd exchange rates at intervals'


### PR DESCRIPTION
This replaces the API call to bter.com (which has closed and been replaced by gate.io) with a call to the Poloniex API to fetch the current rate for the BTC:DOGE book. Poloniex has higher volumes so it was chosen over gate.io's API.